### PR TITLE
Fix savestates

### DIFF
--- a/0001-Fix-out-of-bounds-index-uncovered-by-D_GLIBCXX_ASSER.patch
+++ b/0001-Fix-out-of-bounds-index-uncovered-by-D_GLIBCXX_ASSER.patch
@@ -1,0 +1,27 @@
+From 0fc6d14c9405b73a6005e47e5166a80d595d806d Mon Sep 17 00:00:00 2001
+From: Russell Haley <yumpusamongus@gmail.com>
+Date: Mon, 20 Mar 2023 20:25:41 -0500
+Subject: [PATCH] Fix out-of-bounds index uncovered by -D_GLIBCXX_ASSERTIONS
+
+Flatpak and Fedora packages are built with this flag, and it was causing
+a crash on save. Fixes #5570. Also encountered by manolollr in #5387.
+---
+ src/core/Property.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/Property.cpp b/src/core/Property.cpp
+index ccf20480d..2a17b3afe 100644
+--- a/src/core/Property.cpp
++++ b/src/core/Property.cpp
+@@ -115,7 +115,7 @@ PropertyMap::iterator PropertyMap::iterator::operator++()
+ {
+ 	size_t sz = map->m_keys.size();
+ 	if (map && sz > idx)
+-		while (!map->m_keys[++idx] && idx < sz) {
++		while (++idx < sz && !map->m_keys[idx]) {
+ 		}
+ 	return *this;
+ }
+-- 
+2.42.0
+

--- a/net.pioneerspacesim.Pioneer.json
+++ b/net.pioneerspacesim.Pioneer.json
@@ -74,6 +74,10 @@
 					"url": "https://github.com/pioneerspacesim/pioneer/archive/refs/tags/20230203.tar.gz",
 					"sha256": "80eea94e0f7e4d8e6a0c4629bdfb89201f82aae2f59ee7a1f7a487eeeccf27c7"
 				},
+				{
+					"type": "patch",
+					"path": "0001-Fix-out-of-bounds-index-uncovered-by-D_GLIBCXX_ASSER.patch"
+				},
 				{ 
 					"type": "file", 
 					"path": "pioneer.appdata.xml" 


### PR DESCRIPTION
Cherry-pick a commit from the upstream repository which fixes savestates, which were broken with the last release.